### PR TITLE
refactored extension method error handling:

### DIFF
--- a/Projects/Core/Core/Extensions/ExtensionMethod.h
+++ b/Projects/Core/Core/Extensions/ExtensionMethod.h
@@ -24,21 +24,21 @@ class ExtensionMethod : public Common::Method
 {
 public:
 	ExtensionMethod( IScope* parent,
-			 const std::string& name,
-			 const std::string& type,
-			 Mutability::E mutability = Mutability::Const,
-			 MemoryLayout::E memoryLayout = MemoryLayout::Static,
-			 LanguageFeatureState::E languageFeatureState = LanguageFeatureState::Stable )
+					 const std::string& name,
+					 const std::string& type,
+					 Mutability::E mutability = Mutability::Const,
+					 MemoryLayout::E memoryLayout = MemoryLayout::Static,
+					 LanguageFeatureState::E languageFeatureState = LanguageFeatureState::Stable )
 	: Common::Method( parent, name, Common::TypeDeclaration( type ) )
 	{
-		mIsExtensionMethod = true;
+		mIsExtensionMethod    = true;
 		mLanguageFeatureState = languageFeatureState;
-		mMemoryLayout = memoryLayout;
-		mMethodMutability = mutability;
-		mMutability = Mutability::Modify;
+		mMemoryLayout         = memoryLayout;
+		mMethodMutability     = mutability;
+		mMutability           = Mutability::Modify;
 	}
 
-	virtual Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token ) = 0;
+	virtual Runtime::ControlFlow::E execute(const ParameterList& params, Runtime::Object* result ) = 0;
 };
 
 typedef std::list<ExtensionMethod*> ExtensionMethods;

--- a/Projects/Core/Core/Runtime/Script.cpp
+++ b/Projects/Core/Core/Runtime/Script.cpp
@@ -27,10 +27,10 @@ void Script::execute(Common::ThreadId threadId, const std::string& method, const
 
 	auto* methodSymbol = dynamic_cast<Common::Method*>(symbol);
 
-	Runtime::ControlFlow::E controlflow = Controller::Instance().thread(threadId)->execute(nullptr, methodSymbol, params, result);
+	auto controlflow = Controller::Instance().thread(threadId)->execute(nullptr, methodSymbol, params, result);
 
 	if ( controlflow == Runtime::ControlFlow::Throw ) {
-		Runtime::ExceptionData data = Controller::Instance().thread(threadId)->exception();
+		auto data = Controller::Instance().thread(threadId)->exception();
 
 		std::string text = "Exception raised in " + data.getPosition().toString() + ":\n";
 					text += data.getData()->ToString() + "\n";

--- a/Projects/Core/Core/VirtualMachine/VirtualMachine.cpp
+++ b/Projects/Core/Core/VirtualMachine/VirtualMachine.cpp
@@ -412,9 +412,9 @@ void VirtualMachine::run(Script* script, const ParameterList& params, Runtime::O
 		throw Common::Exceptions::Exception("could not resolve method 'Main(" + toString(params) + ")'");
 	}
 
-	Thread* thread = Controller::Instance().threads()->createThread();
+	auto* thread = Controller::Instance().threads()->createThread();
 
-	Runtime::ControlFlow::E controlflow = thread->execute(nullptr, main, params, result);
+	auto controlflow = thread->execute(nullptr, main, params, result);
 	if ( controlflow == Runtime::ControlFlow::Throw ) {
 		throw Runtime::ControlFlow::Throw;
 	}

--- a/Projects/Extensions/LIBC/CMakeLists.txt
+++ b/Projects/Extensions/LIBC/CMakeLists.txt
@@ -1,7 +1,7 @@
 INCLUDE(${PROJECT_SOURCE_DIR}/CMake/Base.cmake)
 
-#ADD_SUBDIRECTORY(cassert)
-#ADD_SUBDIRECTORY(cstring)
+ADD_SUBDIRECTORY(cassert)
+ADD_SUBDIRECTORY(cstring)
 ADD_SUBDIRECTORY(fenv)
 #ADD_SUBDIRECTORY(locale)
 ADD_SUBDIRECTORY(math)
@@ -10,19 +10,6 @@ ADD_SUBDIRECTORY(stdlib)
 
 
 SET(SOURCES
-    cassert/cassert.h
-    cstring/strcat.h
-    cstring/strchr.h
-    cstring/strcmp.h
-    cstring/strcoll.h
-    cstring/strcspn.h
-    cstring/strlen.h
-    cstring/strncat.h
-    cstring/strncmp.h
-    cstring/strpbrk.h
-    cstring/strspn.h
-    cstring/strrchr.h
-    cstring/strstr.h
     locale/setlocale.h
     Extension.cpp
 )
@@ -36,6 +23,8 @@ SET(DEPENDENCIES
     ExtensionsLIBCStdio
     ExtensionsLIBCMath
     ExtensionsLIBCFenv
+    ExtensionsLIBCCstring
+    ExtensionsLIBCCassert
     CoreExtensions
 )
 

--- a/Projects/Extensions/LIBC/Extension.cpp
+++ b/Projects/Extensions/LIBC/Extension.cpp
@@ -6,19 +6,7 @@
 #include <cerrno>
 
 // Project includes
-#include "cassert/cassert.h"
-#include "cstring/strcat.h"
-#include "cstring/strchr.h"
-#include "cstring/strcmp.h"
-#include "cstring/strcoll.h"
-#include "cstring/strcspn.h"
-#include "cstring/strlen.h"
-#include "cstring/strncat.h"
-#include "cstring/strncmp.h"
-#include "cstring/strpbrk.h"
-#include "cstring/strspn.h"
-#include "cstring/strrchr.h"
-#include "cstring/strstr.h"
+#include <Core/Runtime/BuildInTypes/Int32Type.h>
 #include "locale/setlocale.h"
 
 // Namespace declarations
@@ -30,7 +18,7 @@ namespace LIBC {
 
 
 Extension::Extension()
-: AExtension( "LIBC", "0.1.1" )
+: AExtension( "LIBC", "0.2.0" )
 {
 }
 
@@ -56,6 +44,8 @@ void Extension::initialize( ExtensionNamespace* scope )
 #else
     // Unix/Linux only
 
+    // mCassert.initialize( scope );
+    mCstring.initialize( scope );
     mFenv.initialize( scope );
     mMath.initialize( scope );
     mStdio.initialize( scope );
@@ -67,23 +57,6 @@ void Extension::provideMethods( ExtensionMethods& methods )
 {
     assert( methods.empty() );
 
-    // cassert
-    //methods.push_back( new CASSERT() );
-
-    // cstring
-    methods.push_back( new cstring::STRCAT() );
-    methods.push_back( new cstring::STRCHR() );
-    methods.push_back( new cstring::STRCMP() );
-    methods.push_back( new cstring::STRCOLL() );
-    methods.push_back( new cstring::STRCSPN() );
-    methods.push_back( new cstring::STRLEN() );
-    methods.push_back( new cstring::STRNCAT() );
-    methods.push_back( new cstring::STRNCMP() );
-    methods.push_back( new cstring::STRPBRK() );
-    methods.push_back( new cstring::STRSPN() );
-    methods.push_back( new cstring::STRRCHR() );
-    methods.push_back( new cstring::STRSTR() );
-
     // locale
     methods.push_back( new locale::SETLOCALE() );
 
@@ -92,6 +65,8 @@ void Extension::provideMethods( ExtensionMethods& methods )
 #else
     // Unix/Linux only
 
+    // mCassert.provideMethods( methods );
+    mCstring.provideMethods( methods );
     mFenv.provideMethods( methods );
     mMath.provideMethods( methods );
     mStdio.provideMethods( methods );

--- a/Projects/Extensions/LIBC/Extension.h
+++ b/Projects/Extensions/LIBC/Extension.h
@@ -7,6 +7,8 @@
 
 // Project includes
 #include <Core/Extensions/AExtension.h>
+#include "cassert/cassert.hpp"
+#include "cstring/cstring.hpp"
 #include "fenv/fenv.hpp"
 #include "math/math.hpp"
 #include "stdio/stdio.hpp"
@@ -33,10 +35,12 @@ public:
     void provideMethods( ExtensionMethods& methods ) override;
 
 private:
-    LIBC::fenv::fenv_t     mFenv;
-    LIBC::math::math_t     mMath;
-    LIBC::stdio::stdio_t   mStdio;
-    LIBC::stdlib::stdlib_t mStdlib;
+    LIBC::cassert::cassert_t mCassert;
+    LIBC::cstring::cstring_t mCstring;
+    LIBC::fenv::fenv_t       mFenv;
+    LIBC::math::math_t       mMath;
+    LIBC::stdio::stdio_t     mStdio;
+    LIBC::stdlib::stdlib_t   mStdlib;
 };
 
 

--- a/Projects/Extensions/LIBC/cassert/CMakeLists.txt
+++ b/Projects/Extensions/LIBC/cassert/CMakeLists.txt
@@ -1,0 +1,23 @@
+INCLUDE(${PROJECT_SOURCE_DIR}/CMake/Base.cmake)
+
+SET(SOURCES
+    cassert.cpp
+)
+
+SET(HEADERS
+    cassert.hpp
+)
+
+SET(DEPENDENCIES
+    Utils
+    Core
+)
+
+SET(MODULES
+)
+
+add_include(Projects/Core)
+add_include(Projects/Extensions)
+add_include(Projects/Utils)
+
+build_static_lib(ExtensionsLIBCCassert "${MODULES}")

--- a/Projects/Extensions/LIBC/cassert/cassert.cpp
+++ b/Projects/Extensions/LIBC/cassert/cassert.cpp
@@ -1,0 +1,38 @@
+
+// Header
+#include "cassert.hpp"
+
+// Library includes
+
+// Project includes
+#include "cassert.h"
+
+// Namespace declarations
+
+
+namespace Slang {
+namespace Extensions {
+namespace LIBC {
+namespace cassert {
+
+
+cassert_t::cassert_t()
+: AExtension( "cassert", "0.0.1" )
+{
+}
+
+void cassert_t::initialize( ExtensionNamespace* scope )
+{
+    (void)scope;
+}
+
+void cassert_t::provideMethods( ExtensionMethods& methods )
+{
+    methods.push_back( new CASSERT() );
+}
+
+
+}
+}
+}
+}

--- a/Projects/Extensions/LIBC/cassert/cassert.h
+++ b/Projects/Extensions/LIBC/cassert/cassert.h
@@ -39,7 +39,7 @@ public:
         setSignature(params);
     }
 
-    Runtime::ControlFlow::E execute(Common::ThreadId /*threadId*/, const ParameterList& params, Runtime::Object* /*result*/, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* /*result*/ )
     {
         ParameterList list = mergeParameters(params);
 
@@ -68,7 +68,7 @@ public:
         }
 
         if ( !success ) {
-            throw Runtime::Exceptions::AssertionFailed(param_message, token.position());
+            throw Runtime::Exceptions::AssertionFailed(param_message);
         }
 
         return Runtime::ControlFlow::Normal;

--- a/Projects/Extensions/LIBC/cassert/cassert.hpp
+++ b/Projects/Extensions/LIBC/cassert/cassert.hpp
@@ -1,0 +1,40 @@
+
+#ifndef Slang_Extensions_LIBC_cassert_cassert_hpp
+#define Slang_Extensions_LIBC_cassert_cassert_hpp
+
+
+// Library includes
+
+// Project includes
+#include <Core/Extensions/AExtension.h>
+
+// Forward declarations
+
+// Namespace declarations
+
+
+namespace Slang {
+namespace Extensions {
+namespace LIBC {
+namespace cassert {
+
+
+class cassert_t : public AExtension
+{
+public:
+    cassert_t();
+    ~cassert_t() = default;
+
+public:
+    void initialize( ExtensionNamespace* scope );
+    void provideMethods( ExtensionMethods& methods );
+};
+
+
+}
+}
+}
+}
+
+
+#endif

--- a/Projects/Extensions/LIBC/cstring/CMakeLists.txt
+++ b/Projects/Extensions/LIBC/cstring/CMakeLists.txt
@@ -1,0 +1,23 @@
+INCLUDE(${PROJECT_SOURCE_DIR}/CMake/Base.cmake)
+
+SET(SOURCES
+    cstring.cpp
+)
+
+SET(HEADERS
+    cstring.hpp
+)
+
+SET(DEPENDENCIES
+    Utils
+    Core
+)
+
+SET(MODULES
+)
+
+add_include(Projects/Core)
+add_include(Projects/Extensions)
+add_include(Projects/Utils)
+
+build_static_lib(ExtensionsLIBCCstring "${MODULES}")

--- a/Projects/Extensions/LIBC/cstring/cstring.cpp
+++ b/Projects/Extensions/LIBC/cstring/cstring.cpp
@@ -1,0 +1,62 @@
+
+// Header
+#include "cstring.hpp"
+
+// Library includes
+#include <cstring>
+
+// Project includes
+#include "strcat.h"
+#include "strchr.h"
+#include "strcmp.h"
+#include "strcoll.h"
+#include "strcspn.h"
+#include "strlen.h"
+#include "strncat.h"
+#include "strncmp.h"
+#include "strpbrk.h"
+#include "strspn.h"
+#include "strrchr.h"
+#include "strstr.h"
+
+// Namespace declarations
+
+
+namespace Slang {
+namespace Extensions {
+namespace LIBC {
+namespace cstring {
+
+
+cstring_t::cstring_t()
+: AExtension( "cstring", "0.0.1" )
+{
+}
+
+void cstring_t::initialize( ExtensionNamespace* scope )
+{
+    (void)scope;
+}
+
+void cstring_t::provideMethods( ExtensionMethods& methods )
+{
+    methods.push_back( new cstring::STRCAT() );
+    methods.push_back( new cstring::STRCHR() );
+    methods.push_back( new cstring::STRCMP() );
+    methods.push_back( new cstring::STRCOLL() );
+    methods.push_back( new cstring::STRCSPN() );
+    methods.push_back( new cstring::STRLEN() );
+    methods.push_back( new cstring::STRNCAT() );
+    methods.push_back( new cstring::STRNCMP() );
+    methods.push_back( new cstring::STRPBRK() );
+    methods.push_back( new cstring::STRSPN() );
+    methods.push_back( new cstring::STRRCHR() );
+    methods.push_back( new cstring::STRSTR() );
+
+}
+
+
+}
+}
+}
+}

--- a/Projects/Extensions/LIBC/cstring/cstring.hpp
+++ b/Projects/Extensions/LIBC/cstring/cstring.hpp
@@ -1,0 +1,40 @@
+
+#ifndef Slang_Extensions_LIBC_cstring_cstring_hpp
+#define Slang_Extensions_LIBC_cstring_cstring_hpp
+
+
+// Library includes
+
+// Project includes
+#include <Core/Extensions/AExtension.h>
+
+// Forward declarations
+
+// Namespace declarations
+
+
+namespace Slang {
+namespace Extensions {
+namespace LIBC {
+namespace cstring {
+
+
+class cstring_t : public AExtension
+{
+public:
+    cstring_t();
+    ~cstring_t() = default;
+
+public:
+    void initialize( ExtensionNamespace* scope );
+    void provideMethods( ExtensionMethods& methods );
+};
+
+
+}
+}
+}
+}
+
+
+#endif

--- a/Projects/Extensions/LIBC/cstring/strcat.h
+++ b/Projects/Extensions/LIBC/cstring/strcat.h
@@ -38,25 +38,16 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_destination = (*it++).value().toStdString();
-			auto param_source      = (*it++).value().toStdString();
+		auto param_destination = (*it++).value().toStdString();
+		auto param_source      = (*it++).value().toStdString();
 
-			*result = Runtime::StringType( param_destination + param_source );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType( param_destination + param_source );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strchr.h
+++ b/Projects/Extensions/LIBC/cstring/strchr.h
@@ -40,25 +40,16 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_str = (*it++).value().toStdString();
-			auto param_ch  = (*it++).value().toInt();
+		auto param_str = (*it++).value().toStdString();
+		auto param_ch  = (*it++).value().toInt();
 
-			*result = Runtime::StringType( std::string( strchr( param_str.c_str(), param_ch ) ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType( std::string( strchr( param_str.c_str(), param_ch ) ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strcmp.h
+++ b/Projects/Extensions/LIBC/cstring/strcmp.h
@@ -41,25 +41,16 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_str1 = (*it++).value().toStdString();
-			auto param_str2 = (*it++).value().toStdString();
+		auto param_str1 = (*it++).value().toStdString();
+		auto param_str2 = (*it++).value().toStdString();
 
-			*result = Runtime::Int32Type( strcmp( param_str1.c_str(), param_str2.c_str() ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( strcmp( param_str1.c_str(), param_str2.c_str() ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strcoll.h
+++ b/Projects/Extensions/LIBC/cstring/strcoll.h
@@ -41,25 +41,16 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_str1 = (*it++).value().toStdString();
-			auto param_str2 = (*it++).value().toStdString();
+		auto param_str1 = (*it++).value().toStdString();
+		auto param_str2 = (*it++).value().toStdString();
 
-			*result = Runtime::Int32Type( strcoll( param_str1.c_str(), param_str2.c_str() ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( strcoll( param_str1.c_str(), param_str2.c_str() ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strcspn.h
+++ b/Projects/Extensions/LIBC/cstring/strcspn.h
@@ -41,25 +41,16 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_dest = (*it++).value().toStdString();
-			auto param_src  = (*it++).value().toStdString();
+		auto param_dest = (*it++).value().toStdString();
+		auto param_src  = (*it++).value().toStdString();
 
-			*result = Runtime::Int32Type( strcspn( param_dest.c_str(), param_src.c_str() ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( strcspn( param_dest.c_str(), param_src.c_str() ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strlen.h
+++ b/Projects/Extensions/LIBC/cstring/strlen.h
@@ -38,24 +38,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_value = (*it++).value().toStdString();
+		auto param_value = (*it++).value().toStdString();
 
-			*result = Runtime::Int32Type( static_cast<int32_t>( param_value.size() ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( static_cast<int32_t>( param_value.size() ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strncat.h
+++ b/Projects/Extensions/LIBC/cstring/strncat.h
@@ -40,26 +40,17 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_destination = (*it++).value().toStdString();
-			auto param_source      = (*it++).value().toStdString();
-            auto param_num         = (*it++).value().toInt();
+		auto param_destination = (*it++).value().toStdString();
+		auto param_source      = (*it++).value().toStdString();
+		auto param_num         = (*it++).value().toInt();
 
-			*result = Runtime::StringType( param_destination + param_source.substr( param_num ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType( param_destination + param_source.substr( param_num ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strncmp.h
+++ b/Projects/Extensions/LIBC/cstring/strncmp.h
@@ -41,26 +41,17 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_str1 = (*it++).value().toStdString();
-			auto param_str2 = (*it++).value().toStdString();
-			auto param_num  = (*it++).value().toInt();
+		auto param_str1 = (*it++).value().toStdString();
+		auto param_str2 = (*it++).value().toStdString();
+		auto param_num  = (*it++).value().toInt();
 
-			*result = Runtime::Int32Type( strncmp( param_str1.c_str(), param_str2.c_str(), param_num ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( strncmp( param_str1.c_str(), param_str2.c_str(), param_num ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strpbrk.h
+++ b/Projects/Extensions/LIBC/cstring/strpbrk.h
@@ -39,25 +39,16 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_dest     = (*it++).value().toStdString();
-			auto param_breakset = (*it++).value().toStdString();
+		auto param_dest     = (*it++).value().toStdString();
+		auto param_breakset = (*it++).value().toStdString();
 
-			*result = Runtime::StringType( std::string( strpbrk( param_dest.c_str(), param_breakset.c_str() ) ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType( std::string( strpbrk( param_dest.c_str(), param_breakset.c_str() ) ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strrchr.h
+++ b/Projects/Extensions/LIBC/cstring/strrchr.h
@@ -41,25 +41,16 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_str = (*it++).value().toStdString();
-			auto param_ch  = (*it++).value().toInt();
+		auto param_str = (*it++).value().toStdString();
+		auto param_ch  = (*it++).value().toInt();
 
-			*result = Runtime::StringType( std::string( strrchr( param_str.c_str(), param_ch ) ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType( std::string( strrchr( param_str.c_str(), param_ch ) ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strspn.h
+++ b/Projects/Extensions/LIBC/cstring/strspn.h
@@ -41,25 +41,16 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_dest = (*it++).value().toStdString();
-			auto param_src  = (*it++).value().toStdString();
+		auto param_dest = (*it++).value().toStdString();
+		auto param_src  = (*it++).value().toStdString();
 
-			*result = Runtime::Int32Type( strspn( param_dest.c_str(), param_src.c_str() ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( strspn( param_dest.c_str(), param_src.c_str() ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/cstring/strstr.h
+++ b/Projects/Extensions/LIBC/cstring/strstr.h
@@ -39,25 +39,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_str    = (*it++).value().toStdString();
-			auto param_substr = (*it++).value().toStdString();
+		auto param_str    = (*it++).value().toStdString();
+		auto param_substr = (*it++).value().toStdString();
 
-			*result = Runtime::StringType( std::string( strstr( param_str.c_str(), param_substr.c_str() ) ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType( std::string( strstr( param_str.c_str(), param_substr.c_str() ) ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/fenv/feclearexcept.h
+++ b/Projects/Extensions/LIBC/fenv/feclearexcept.h
@@ -38,24 +38,15 @@ public:
         setSignature(params);
     }
 
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
     {
         ParameterList list = mergeParameters(params);
 
-        try {
-            ParameterList::const_iterator it = list.begin();
+        ParameterList::const_iterator it = list.begin();
 
-            auto param_excepts = (*it++).value().toInt();
+        auto param_excepts = (*it++).value().toInt();
 
-            *result = Runtime::Int32Type(feclearexcept(param_excepts));
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        *result = Runtime::Int32Type(feclearexcept(param_excepts));
 
         return Runtime::ControlFlow::Normal;
     }

--- a/Projects/Extensions/LIBC/fenv/fegetround.h
+++ b/Projects/Extensions/LIBC/fenv/fegetround.h
@@ -37,20 +37,11 @@ public:
         setSignature(params);
     }
 
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
     {
         ParameterList list = mergeParameters(params);
 
-        try {
-            *result = Runtime::Int32Type(fegetround());
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        *result = Runtime::Int32Type(fegetround());
 
         return Runtime::ControlFlow::Normal;
     }

--- a/Projects/Extensions/LIBC/fenv/feraiseexcept.h
+++ b/Projects/Extensions/LIBC/fenv/feraiseexcept.h
@@ -38,24 +38,15 @@ public:
         setSignature(params);
     }
 
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
     {
         ParameterList list = mergeParameters(params);
 
-        try {
-            ParameterList::const_iterator it = list.begin();
+        ParameterList::const_iterator it = list.begin();
 
-            auto param_excepts = (*it++).value().toInt();
+        auto param_excepts = (*it++).value().toInt();
 
-            *result = Runtime::Int32Type(feraiseexcept(param_excepts));
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        *result = Runtime::Int32Type(feraiseexcept(param_excepts));
 
         return Runtime::ControlFlow::Normal;
     }

--- a/Projects/Extensions/LIBC/fenv/fesetround.h
+++ b/Projects/Extensions/LIBC/fenv/fesetround.h
@@ -38,24 +38,15 @@ public:
         setSignature(params);
     }
 
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
     {
         ParameterList list = mergeParameters(params);
 
-        try {
-            ParameterList::const_iterator it = list.begin();
+        ParameterList::const_iterator it = list.begin();
 
-            auto param_round = (*it++).value().toInt();
+        auto param_round = (*it++).value().toInt();
 
-            *result = Runtime::Int32Type(fesetround(param_round));
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        *result = Runtime::Int32Type(fesetround(param_round));
 
         return Runtime::ControlFlow::Normal;
     }

--- a/Projects/Extensions/LIBC/fenv/fetestexcept.h
+++ b/Projects/Extensions/LIBC/fenv/fetestexcept.h
@@ -38,24 +38,15 @@ public:
         setSignature(params);
     }
 
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
     {
         ParameterList list = mergeParameters(params);
 
-        try {
-            ParameterList::const_iterator it = list.begin();
+        ParameterList::const_iterator it = list.begin();
 
-            auto param_excepts = (*it++).value().toInt();
+        auto param_excepts = (*it++).value().toInt();
 
-            *result = Runtime::Int32Type(fetestexcept(param_excepts));
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        *result = Runtime::Int32Type(fetestexcept(param_excepts));
 
         return Runtime::ControlFlow::Normal;
     }

--- a/Projects/Extensions/LIBC/locale/setlocale.h
+++ b/Projects/Extensions/LIBC/locale/setlocale.h
@@ -7,6 +7,7 @@
 #include <cassert>
 
 // Project includes
+#include <Core/Designtime/BuildInTypes/Int32Type.h>
 #include <Core/Designtime/BuildInTypes/StringType.h>
 #include <Core/Runtime/BuildInTypes/StringType.h>
 #include <Core/Extensions/ExtensionMethod.h>
@@ -38,25 +39,16 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_category = (*it++).value().toInt();
-			auto param_locale   = (*it++).value().toStdString();
+		auto param_category = (*it++).value().toInt();
+		auto param_locale   = (*it++).value().toStdString();
 
-			*result = Runtime::StringType( std::string( setlocale( param_category, param_locale.c_str() ) ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType( std::string( setlocale( param_category, param_locale.c_str() ) ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/abs.h
+++ b/Projects/Extensions/LIBC/math/abs.h
@@ -45,24 +45,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_n = (*it++).value().toInt();
+		auto param_n = (*it++).value().toInt();
 
-			*result = Runtime::Int32Type( abs( static_cast<int32_t>( param_n ) ) );
-		}
-		catch ( std::exception& e ) {
-			auto *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( abs( static_cast<int32_t>( param_n ) ) );
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -82,24 +73,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_n = (*it++).value().toDouble();
+		auto param_n = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(fabs(param_n));
-		}
-		catch ( std::exception& e ) {
-			auto *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(fabs(param_n));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -119,24 +101,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_n = (*it++).value().toFloat();
+		auto param_n = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(fabsf(param_n));
-		}
-		catch ( std::exception& e ) {
-			auto *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(fabsf(param_n));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -156,24 +129,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_n = (*it++).value().toInt();
+		auto param_n = (*it++).value().toInt();
 
-			*result = Runtime::Int64Type( labs( param_n ) );
-		}
-		catch ( std::exception& e ) {
-			auto *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int64Type( labs( param_n ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/acos.h
+++ b/Projects/Extensions/LIBC/math/acos.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(acos(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(acos(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(acosf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(acosf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/acosh.h
+++ b/Projects/Extensions/LIBC/math/acosh.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(acosh(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(acosh(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(acoshf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(acoshf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/asin.h
+++ b/Projects/Extensions/LIBC/math/asin.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(asin(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(asin(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(asinf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(asinf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/asinh.h
+++ b/Projects/Extensions/LIBC/math/asinh.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(asinh(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(asinh(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(asinhf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(asinhf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/atan.h
+++ b/Projects/Extensions/LIBC/math/atan.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(atan(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(atan(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(atanf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(atanf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/atan2.h
+++ b/Projects/Extensions/LIBC/math/atan2.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toDouble();
-			auto param_y = (*it++).value().toDouble();
+		auto param_x = (*it++).value().toDouble();
+		auto param_y = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(atan2(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(atan2(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toFloat();
-			auto param_y = (*it++).value().toFloat();
+		auto param_x = (*it++).value().toFloat();
+		auto param_y = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(atan2f(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(atan2f(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/atanh.h
+++ b/Projects/Extensions/LIBC/math/atanh.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(atanh(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(atanh(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(atanhf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(atanhf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/cbrt.h
+++ b/Projects/Extensions/LIBC/math/cbrt.h
@@ -41,24 +41,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(cbrt(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(cbrt(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -78,24 +69,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(cbrtf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(cbrtf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/ceil.h
+++ b/Projects/Extensions/LIBC/math/ceil.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(ceil(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(ceil(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::FloatType(ceilf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(ceilf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/copysign.h
+++ b/Projects/Extensions/LIBC/math/copysign.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toDouble();
-			auto param_y = (*it++).value().toDouble();
+		auto param_x = (*it++).value().toDouble();
+		auto param_y = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(copysign(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(copysign(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toFloat();
-			auto param_y = (*it++).value().toFloat();
+		auto param_x = (*it++).value().toFloat();
+		auto param_y = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(copysignf(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(copysignf(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/cos.h
+++ b/Projects/Extensions/LIBC/math/cos.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(cos(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(cos(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(cosf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(cosf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/cosh.h
+++ b/Projects/Extensions/LIBC/math/cosh.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(cosh(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(cosh(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(coshf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(coshf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/erf.h
+++ b/Projects/Extensions/LIBC/math/erf.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(erf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(erf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(erff(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(erff(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/erfc.h
+++ b/Projects/Extensions/LIBC/math/erfc.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(erfc(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(erfc(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(erfcf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(erfcf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/exp.h
+++ b/Projects/Extensions/LIBC/math/exp.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(exp(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(exp(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(expf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(expf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/exp2.h
+++ b/Projects/Extensions/LIBC/math/exp2.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(exp2(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(exp2(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(exp2f(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(exp2f(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/expm1.h
+++ b/Projects/Extensions/LIBC/math/expm1.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(expm1(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(expm1(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(expm1f(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(expm1f(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/fdim.h
+++ b/Projects/Extensions/LIBC/math/fdim.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toDouble();
-			auto param_y = (*it++).value().toDouble();
+		auto param_x = (*it++).value().toDouble();
+		auto param_y = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(fdim(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(fdim(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toFloat();
-			auto param_y = (*it++).value().toFloat();
+		auto param_x = (*it++).value().toFloat();
+		auto param_y = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(fdimf(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(fdimf(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/floor.h
+++ b/Projects/Extensions/LIBC/math/floor.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(floor(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(floor(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::FloatType(floorf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(floorf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/fma.h
+++ b/Projects/Extensions/LIBC/math/fma.h
@@ -43,26 +43,17 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toDouble();
-			auto param_y = (*it++).value().toDouble();
-			auto param_z = (*it++).value().toDouble();
+		auto param_x = (*it++).value().toDouble();
+		auto param_y = (*it++).value().toDouble();
+		auto param_z = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(fma(param_x, param_y, param_z));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(fma(param_x, param_y, param_z));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -84,26 +75,17 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toFloat();
-			auto param_y = (*it++).value().toFloat();
-			auto param_z = (*it++).value().toFloat();
+		auto param_x = (*it++).value().toFloat();
+		auto param_y = (*it++).value().toFloat();
+		auto param_z = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(fmaf(param_x, param_y, param_z));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(fmaf(param_x, param_y, param_z));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/fmax.h
+++ b/Projects/Extensions/LIBC/math/fmax.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toDouble();
-			auto param_y = (*it++).value().toDouble();
+		auto param_x = (*it++).value().toDouble();
+		auto param_y = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(fmax(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(fmax(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toFloat();
-			auto param_y = (*it++).value().toFloat();
+		auto param_x = (*it++).value().toFloat();
+		auto param_y = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(fmaxf(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(fmaxf(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/fmin.h
+++ b/Projects/Extensions/LIBC/math/fmin.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toDouble();
-			auto param_y = (*it++).value().toDouble();
+		auto param_x = (*it++).value().toDouble();
+		auto param_y = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(fmin(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(fmin(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toFloat();
-			auto param_y = (*it++).value().toFloat();
+		auto param_x = (*it++).value().toFloat();
+		auto param_y = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(fminf(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(fminf(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/fmod.h
+++ b/Projects/Extensions/LIBC/math/fmod.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toDouble();
-			auto param_y = (*it++).value().toDouble();
+		auto param_x = (*it++).value().toDouble();
+		auto param_y = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(fmod(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(fmod(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toFloat();
-			auto param_y = (*it++).value().toFloat();
+		auto param_x = (*it++).value().toFloat();
+		auto param_y = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(fmodf(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(fmodf(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/hypot.h
+++ b/Projects/Extensions/LIBC/math/hypot.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toDouble();
-			auto param_y = (*it++).value().toDouble();
+		auto param_x = (*it++).value().toDouble();
+		auto param_y = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(hypot(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(hypot(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toFloat();
-			auto param_y = (*it++).value().toFloat();
+		auto param_x = (*it++).value().toFloat();
+		auto param_y = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(hypotf(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(hypotf(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/ilogb.h
+++ b/Projects/Extensions/LIBC/math/ilogb.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(ilogb(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(ilogb(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(ilogbf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(ilogbf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/ldexp.h
+++ b/Projects/Extensions/LIBC/math/ldexp.h
@@ -40,25 +40,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
-			auto param_exp = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
+		auto param_exp = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(ldexp(param_arg, param_exp));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(ldexp(param_arg, param_exp));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,25 +70,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
-			auto param_exp = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
+		auto param_exp = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(ldexpf(param_arg, param_exp));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(ldexpf(param_arg, param_exp));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/lgamma.h
+++ b/Projects/Extensions/LIBC/math/lgamma.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(lgamma(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(lgamma(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::DoubleType(lgammaf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(lgammaf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/log.h
+++ b/Projects/Extensions/LIBC/math/log.h
@@ -41,24 +41,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_n = (*it++).value().toDouble();
+		auto param_n = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(log(param_n));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(log(param_n));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -78,24 +69,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_value = (*it++).value().toFloat();
+		auto param_value = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(logf(param_value));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(logf(param_value));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/log10.h
+++ b/Projects/Extensions/LIBC/math/log10.h
@@ -41,24 +41,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_n = (*it++).value().toDouble();
+		auto param_n = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(log10(param_n));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(log10(param_n));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -78,24 +69,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_value = (*it++).value().toFloat();
+		auto param_value = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(log10f(param_value));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(log10f(param_value));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/log1p.h
+++ b/Projects/Extensions/LIBC/math/log1p.h
@@ -41,24 +41,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_n = (*it++).value().toDouble();
+		auto param_n = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(log1p(param_n));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(log1p(param_n));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -78,24 +69,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_value = (*it++).value().toFloat();
+		auto param_value = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(log1pf(param_value));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(log1pf(param_value));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/log2.h
+++ b/Projects/Extensions/LIBC/math/log2.h
@@ -41,24 +41,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_n = (*it++).value().toDouble();
+		auto param_n = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(log2(param_n));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(log2(param_n));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -78,24 +69,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_value = (*it++).value().toFloat();
+		auto param_value = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(log2f(param_value));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(log2f(param_value));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/logb.h
+++ b/Projects/Extensions/LIBC/math/logb.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(logb(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(logb(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(logbf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(logbf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/nan.h
+++ b/Projects/Extensions/LIBC/math/nan.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toStdString();
+		auto param_arg = (*it++).value().toStdString();
 
-			*result = Runtime::DoubleType(nan(param_arg.c_str()));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(nan(param_arg.c_str()));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toStdString();
+		auto param_arg = (*it++).value().toStdString();
 
-			*result = Runtime::FloatType(nanf(param_arg.c_str()));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(nanf(param_arg.c_str()));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/nearbyint.h
+++ b/Projects/Extensions/LIBC/math/nearbyint.h
@@ -38,24 +38,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(nearbyint(param_arg));
-		}
-		catch ( std::exception& e ) {
-			auto *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(nearbyint(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -75,24 +66,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::FloatType(nearbyintf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			auto *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(nearbyintf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/nextafter.h
+++ b/Projects/Extensions/LIBC/math/nextafter.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_from = (*it++).value().toDouble();
-			auto param_to   = (*it++).value().toDouble();
+		auto param_from = (*it++).value().toDouble();
+		auto param_to   = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(nextafter(param_from, param_to));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(nextafter(param_from, param_to));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_from = (*it++).value().toFloat();
-			auto param_to   = (*it++).value().toFloat();
+		auto param_from = (*it++).value().toFloat();
+		auto param_to   = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(nextafterf(param_from, param_to));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(nextafterf(param_from, param_to));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/nexttoward.h
+++ b/Projects/Extensions/LIBC/math/nexttoward.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_from = (*it++).value().toDouble();
-			auto param_to   = (*it++).value().toDouble();
+		auto param_from = (*it++).value().toDouble();
+		auto param_to   = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(nexttoward(param_from, param_to));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(nexttoward(param_from, param_to));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_from = (*it++).value().toFloat();
-			auto param_to   = (*it++).value().toFloat();
+		auto param_from = (*it++).value().toFloat();
+		auto param_to   = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(nexttowardf(param_from, param_to));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(nexttowardf(param_from, param_to));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/pow.h
+++ b/Projects/Extensions/LIBC/math/pow.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_base     = (*it++).value().toDouble();
-			auto param_exponent = (*it++).value().toDouble();
+		auto param_base     = (*it++).value().toDouble();
+		auto param_exponent = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(pow(param_base, param_exponent));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(pow(param_base, param_exponent));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_base     = (*it++).value().toFloat();
-			auto param_exponent = (*it++).value().toFloat();
+		auto param_base     = (*it++).value().toFloat();
+		auto param_exponent = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(powf(param_base, param_exponent));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(powf(param_base, param_exponent));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -120,25 +102,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_base     = (*it++).value().toInt();
-			auto param_exponent = (*it++).value().toInt();
+		auto param_base     = (*it++).value().toInt();
+		auto param_exponent = (*it++).value().toInt();
 
-			*result = Runtime::Int64Type( powl( param_base, param_exponent ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int64Type( powl( param_base, param_exponent ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/remainder.h
+++ b/Projects/Extensions/LIBC/math/remainder.h
@@ -42,25 +42,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toDouble();
-			auto param_y = (*it++).value().toDouble();
+		auto param_x = (*it++).value().toDouble();
+		auto param_y = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(remainder(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(remainder(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -81,25 +72,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_x = (*it++).value().toFloat();
-			auto param_y = (*it++).value().toFloat();
+		auto param_x = (*it++).value().toFloat();
+		auto param_y = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(remainderf(param_x, param_y));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(remainderf(param_x, param_y));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/rint.h
+++ b/Projects/Extensions/LIBC/math/rint.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(rint(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(rint(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::FloatType(rintf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(rintf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/round.h
+++ b/Projects/Extensions/LIBC/math/round.h
@@ -39,28 +39,19 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
 #ifdef _WIN32
-			*result = Runtime::DoubleType(floor(param_arg + 0.5));
+		*result = Runtime::DoubleType(floor(param_arg + 0.5));
 #else
-			*result = Runtime::DoubleType(round(param_arg));
+		*result = Runtime::DoubleType(round(param_arg));
 #endif
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -80,28 +71,19 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
 #ifdef _WIN32
-			*result = Runtime::FloatType(floorf(param_arg + 0.5f));
+		*result = Runtime::FloatType(floorf(param_arg + 0.5f));
 #else
-			*result = Runtime::FloatType(roundf(param_arg));
+		*result = Runtime::FloatType(roundf(param_arg));
 #endif
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/scalbn.h
+++ b/Projects/Extensions/LIBC/math/scalbn.h
@@ -40,25 +40,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
-			auto param_exp = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
+		auto param_exp = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(scalbn(param_arg, param_exp));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(scalbn(param_arg, param_exp));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,25 +70,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
-			auto param_exp = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
+		auto param_exp = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(scalbnf(param_arg, param_exp));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(scalbnf(param_arg, param_exp));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/sin.h
+++ b/Projects/Extensions/LIBC/math/sin.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(sin(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(sin(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(sinf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(sinf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/sinh.h
+++ b/Projects/Extensions/LIBC/math/sinh.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(sinh(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(sinh(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(sinhf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(sinhf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/sqrt.h
+++ b/Projects/Extensions/LIBC/math/sqrt.h
@@ -41,24 +41,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(sqrt(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(sqrt(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -78,24 +69,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(sqrt(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(sqrt(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -115,24 +97,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(sqrtf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(sqrtf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/tan.h
+++ b/Projects/Extensions/LIBC/math/tan.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(tan(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(tan(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(tanf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(tanf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/tanh.h
+++ b/Projects/Extensions/LIBC/math/tanh.h
@@ -42,24 +42,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(tanh(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(tanh(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -79,24 +70,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::FloatType(tanhf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(tanhf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/tgamma.h
+++ b/Projects/Extensions/LIBC/math/tgamma.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
-			*result = Runtime::DoubleType(tgamma(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(tgamma(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,24 +67,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
-			*result = Runtime::DoubleType(tgammaf(param_arg));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(tgammaf(param_arg));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/math/trunc.h
+++ b/Projects/Extensions/LIBC/math/trunc.h
@@ -39,28 +39,19 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toDouble();
+		auto param_arg = (*it++).value().toDouble();
 
 #ifdef _WIN32
-			*result = Runtime::DoubleType((param_arg > 0) ? floor(param_arg) : ceil(param_arg));
+		*result = Runtime::DoubleType((param_arg > 0) ? floor(param_arg) : ceil(param_arg));
 #else
-			*result = Runtime::DoubleType(trunc(param_arg));
+		*result = Runtime::DoubleType(trunc(param_arg));
 #endif
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -80,28 +71,19 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_arg = (*it++).value().toFloat();
+		auto param_arg = (*it++).value().toFloat();
 
 #ifdef _WIN32
-			*result = Runtime::FloatType((param_arg > 0) ? floorf(param_arg) : ceilf(param_arg));
+		*result = Runtime::FloatType((param_arg > 0) ? floorf(param_arg) : ceilf(param_arg));
 #else
-			*result = Runtime::FloatType(truncf(param_arg));
+		*result = Runtime::FloatType(truncf(param_arg));
 #endif
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/clearerr.h
+++ b/Projects/Extensions/LIBC/stdio/clearerr.h
@@ -38,28 +38,19 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object */*result*/, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object */*result*/ )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_stream = (*it++).value().toInt();
+		auto param_stream = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_stream) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			clearerr( stdio_t::FileHandles[ param_stream ] );
+		if ( stdio_t::FileHandles.find(param_stream) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		clearerr( stdio_t::FileHandles[ param_stream ] );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/fclose.h
+++ b/Projects/Extensions/LIBC/stdio/fclose.h
@@ -38,33 +38,24 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			int fileResult = fclose(stdio_t::FileHandles[param_handle]);
-			if ( fileResult == -1 ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			*result = Runtime::Int32Type(fileResult);
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		int fileResult = fclose(stdio_t::FileHandles[param_handle]);
+		if ( fileResult == -1 ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
+
+		*result = Runtime::Int32Type(fileResult);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/feof.h
+++ b/Projects/Extensions/LIBC/stdio/feof.h
@@ -38,28 +38,19 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_stream = (*it++).value().toInt();
+		auto param_stream = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_stream) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			*result = Runtime::Int32Type( feof( stdio_t::FileHandles[ param_stream ] ) );
+		if ( stdio_t::FileHandles.find(param_stream) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( feof( stdio_t::FileHandles[ param_stream ] ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/ferror.h
+++ b/Projects/Extensions/LIBC/stdio/ferror.h
@@ -47,28 +47,19 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_stream = (*it++).value().toInt();
+		auto param_stream = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_stream) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			*result = Runtime::Int32Type( ferror( stdio_t::FileHandles[ param_stream ] ) );
+		if ( stdio_t::FileHandles.find(param_stream) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( ferror( stdio_t::FileHandles[ param_stream ] ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/fflush.h
+++ b/Projects/Extensions/LIBC/stdio/fflush.h
@@ -42,30 +42,21 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			auto value = fflush( stdio_t::FileHandles[ param_handle ] );
-
-			*result = Runtime::Int32Type( value );
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		auto value = fflush( stdio_t::FileHandles[ param_handle ] );
+
+		*result = Runtime::Int32Type( value );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/fgetc.h
+++ b/Projects/Extensions/LIBC/stdio/fgetc.h
@@ -44,28 +44,19 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_stream = (*it++).value().toInt();
+		auto param_stream = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find( param_stream ) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
-			}
-
-			*result = Runtime::StringType( std::to_string( fgetc( stdio_t::FileHandles[ param_stream ] ) ) );
+		if ( stdio_t::FileHandles.find( param_stream ) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
 
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType( std::to_string( fgetc( stdio_t::FileHandles[ param_stream ] ) ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/fgets.h
+++ b/Projects/Extensions/LIBC/stdio/fgets.h
@@ -45,41 +45,32 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
-			auto param_size   = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
+		auto param_size   = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find( param_handle ) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
-			}
-
-			int32_t remainingSize{0};
-			while ( remainingSize < param_size ) {
-				auto readSize = param_size - remainingSize;
-				if ( readSize > READ_SIZE ) {
-					readSize = READ_SIZE;
-				}
-
-				char stream[READ_SIZE];
-				if ( fgets( stream, readSize, stdio_t::FileHandles[ param_handle ] ) != nullptr ) {
-					*result = Runtime::StringType( std::string( stream ) );
-				}
-
-				remainingSize += readSize;
-			}
+		if ( stdio_t::FileHandles.find( param_handle ) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
 
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
+		int32_t remainingSize{0};
+		while ( remainingSize < param_size ) {
+			auto readSize = param_size - remainingSize;
+			if ( readSize > READ_SIZE ) {
+				readSize = READ_SIZE;
+			}
+
+			char stream[READ_SIZE];
+			if ( fgets( stream, readSize, stdio_t::FileHandles[ param_handle ] ) != nullptr ) {
+				*result = Runtime::StringType( std::string( stream ) );
+			}
+
+			remainingSize += readSize;
 		}
 
 		return Runtime::ControlFlow::Normal;

--- a/Projects/Extensions/LIBC/stdio/fopen.h
+++ b/Projects/Extensions/LIBC/stdio/fopen.h
@@ -40,35 +40,25 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_filename = (*it++).value().toStdString();
-			std::string param_accessmode = (*it++).value().toStdString();
+		std::string param_filename = (*it++).value().toStdString();
+		std::string param_accessmode = (*it++).value().toStdString();
 
-			int result_handle = 0;
+		int result_handle = 0;
 
-			FILE* fileHandle = fopen(param_filename.c_str(), param_accessmode.c_str());
-			if ( fileHandle ) {
-				result_handle = stdio_t::FileHandles.size();
+		FILE* fileHandle = fopen(param_filename.c_str(), param_accessmode.c_str());
+		if ( fileHandle ) {
+			result_handle = stdio_t::FileHandles.size();
 
-				stdio_t::FileHandles.insert(std::make_pair(result_handle, fileHandle));
-			}
-
-			*result = Runtime::Int32Type(result_handle);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+			stdio_t::FileHandles.insert(std::make_pair(result_handle, fileHandle));
 		}
 
+		*result = Runtime::Int32Type(result_handle);
 		return Runtime::ControlFlow::Normal;
 	}
 

--- a/Projects/Extensions/LIBC/stdio/fputc.h
+++ b/Projects/Extensions/LIBC/stdio/fputc.h
@@ -44,29 +44,20 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_ch     = (*it++).value().toInt();
-			auto param_stream = (*it++).value().toInt();
+		auto param_ch     = (*it++).value().toInt();
+		auto param_stream = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find( param_stream ) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
-			}
-
-			*result = Runtime::Int32Type( fputc( param_ch, stdio_t::FileHandles[ param_stream ] ) );
+		if ( stdio_t::FileHandles.find( param_stream ) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
 
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( fputc( param_ch, stdio_t::FileHandles[ param_stream ] ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/fputs.h
+++ b/Projects/Extensions/LIBC/stdio/fputs.h
@@ -45,29 +45,20 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_str    = (*it++).value().toStdString();
-			auto param_stream = (*it++).value().toInt();
+		auto param_str    = (*it++).value().toStdString();
+		auto param_stream = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find( param_stream ) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
-			}
-
-			*result = Runtime::Int32Type( fputs( param_str.c_str(), stdio_t::FileHandles[ param_stream ] ) );
+		if ( stdio_t::FileHandles.find( param_stream ) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
 
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( fputs( param_str.c_str(), stdio_t::FileHandles[ param_stream ] ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/fread.h
+++ b/Projects/Extensions/LIBC/stdio/fread.h
@@ -46,35 +46,26 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			bool value = false;
-
-			long size = fread(&value, 1, sizeof(bool), stdio_t::FileHandles[param_handle]);
-			if ( size == -1 ) {    // error while reading
-				throw Runtime::Exceptions::RuntimeException("error while reading file");
-			}
-
-			*result = Runtime::BoolType(value);
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		bool value = false;
+
+		long size = fread(&value, 1, sizeof(bool), stdio_t::FileHandles[param_handle]);
+		if ( size == -1 ) {    // error while reading
+			throw Runtime::Exceptions::RuntimeException("error while reading file");
 		}
+
+		*result = Runtime::BoolType(value);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -93,35 +84,26 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			double value = 0.0;
-
-			long size = fread(&value, 1, sizeof(double), stdio_t::FileHandles[param_handle]);
-			if ( size == -1 ) {    // error while reading
-				throw Runtime::Exceptions::RuntimeException("error while reading file");
-			}
-
-			*result = Runtime::DoubleType(value);
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		double value = 0.0;
+
+		long size = fread(&value, 1, sizeof(double), stdio_t::FileHandles[param_handle]);
+		if ( size == -1 ) {    // error while reading
+			throw Runtime::Exceptions::RuntimeException("error while reading file");
 		}
+
+		*result = Runtime::DoubleType(value);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -140,35 +122,26 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			float value = 0.f;
-
-			long size = fread(&value, 1, sizeof(float), stdio_t::FileHandles[param_handle]);
-			if ( size == -1 ) {    // error while reading
-				throw Runtime::Exceptions::RuntimeException("error while reading file");
-			}
-
-			*result = Runtime::FloatType(value);
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		float value = 0.f;
+
+		long size = fread(&value, 1, sizeof(float), stdio_t::FileHandles[param_handle]);
+		if ( size == -1 ) {    // error while reading
+			throw Runtime::Exceptions::RuntimeException("error while reading file");
 		}
+
+		*result = Runtime::FloatType(value);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -187,35 +160,26 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			int value = 0;
-
-			long size = fread(&value, 1, sizeof(int), stdio_t::FileHandles[param_handle]);
-			if ( size == -1 ) {    // error while reading
-				throw Runtime::Exceptions::RuntimeException("error while reading file");
-			}
-
-			*result = Runtime::Int32Type(value);
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		int value = 0;
+
+		long size = fread(&value, 1, sizeof(int), stdio_t::FileHandles[param_handle]);
+		if ( size == -1 ) {    // error while reading
+			throw Runtime::Exceptions::RuntimeException("error while reading file");
 		}
+
+		*result = Runtime::Int32Type(value);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -235,49 +199,40 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
-			auto param_length = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
+		auto param_length = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
+		}
+
+		std::string value;
+
+		while ( param_length > 0 || param_length == -1 ) {
+			char charValue;
+
+			long size = fread(&charValue, 1, sizeof(char), stdio_t::FileHandles[param_handle]);
+			if ( size == -1 ) {    // error while reading
+				return Runtime::ControlFlow::Throw;
+			}
+			if ( size == 0 ) {	// EOF reached
+				break;
 			}
 
-			std::string value;
+			value += charValue;
 
-			while ( param_length > 0 || param_length == -1 ) {
-				char charValue;
-
-				long size = fread(&charValue, 1, sizeof(char), stdio_t::FileHandles[param_handle]);
-				if ( size == -1 ) {    // error while reading
-					return Runtime::ControlFlow::Throw;
-				}
-				if ( size == 0 ) {	// EOF reached
-					break;
-				}
-
-				value += charValue;
-
-				if ( param_length > 0 ) {
-					param_length--;
-				}
+			if ( param_length > 0 ) {
+				param_length--;
 			}
-
-			*result = Runtime::StringType(value);
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType(value);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/fseek.h
+++ b/Projects/Extensions/LIBC/stdio/fseek.h
@@ -48,35 +48,26 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
-			auto param_offset = (*it++).value().toInt();
-			auto param_origin = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
+		auto param_offset = (*it++).value().toInt();
+		auto param_origin = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find( param_handle ) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
-			}
-
-			long size = fseek( stdio_t::FileHandles[param_handle], param_offset, param_origin );
-			if ( size == -1 ) {
-				throw Runtime::Exceptions::RuntimeException( "error while seeking file" );
-			}
-
-			*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
+		if ( stdio_t::FileHandles.find( param_handle ) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
 
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
+		long size = fseek( stdio_t::FileHandles[param_handle], param_offset, param_origin );
+		if ( size == -1 ) {
+			throw Runtime::Exceptions::RuntimeException( "error while seeking file" );
 		}
+
+		*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/ftell.h
+++ b/Projects/Extensions/LIBC/stdio/ftell.h
@@ -46,33 +46,24 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_stream = (*it++).value().toInt();
+		auto param_stream = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_stream) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			long size = ftell(stdio_t::FileHandles[param_stream]);
-			if ( size == -1 ) {
-				throw Runtime::Exceptions::RuntimeException("error while telling file");
-			}
-
-			*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
+		if ( stdio_t::FileHandles.find(param_stream) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		long size = ftell(stdio_t::FileHandles[param_stream]);
+		if ( size == -1 ) {
+			throw Runtime::Exceptions::RuntimeException("error while telling file");
 		}
+
+		*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/fwrite.h
+++ b/Projects/Extensions/LIBC/stdio/fwrite.h
@@ -46,35 +46,26 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			bool param_value = (*it++).value().toBool();
-
-			long size = fwrite(&param_value, sizeof(bool), 1, stdio_t::FileHandles[param_handle]);
-			if ( size == -1 ) {    // error while writing
-				throw Runtime::Exceptions::RuntimeException("error while writing file");
-			}
-
-			*result = Runtime::Int32Type((int)size);
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		bool param_value = (*it++).value().toBool();
+
+		long size = fwrite(&param_value, sizeof(bool), 1, stdio_t::FileHandles[param_handle]);
+		if ( size == -1 ) {    // error while writing
+			throw Runtime::Exceptions::RuntimeException("error while writing file");
 		}
+
+		*result = Runtime::Int32Type((int)size);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -94,35 +85,26 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			double param_value = (*it++).value().toDouble();
-
-			long size = fwrite(&param_value, sizeof(double), 1, stdio_t::FileHandles[param_handle]);
-			if ( size == -1 ) {    // error while writing
-				throw Runtime::Exceptions::RuntimeException("error while writing file");
-			}
-
-			*result = Runtime::Int32Type((int)size);
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		double param_value = (*it++).value().toDouble();
+
+		long size = fwrite(&param_value, sizeof(double), 1, stdio_t::FileHandles[param_handle]);
+		if ( size == -1 ) {    // error while writing
+			throw Runtime::Exceptions::RuntimeException("error while writing file");
 		}
+
+		*result = Runtime::Int32Type((int)size);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -142,35 +124,26 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			float param_value = (*it++).value().toFloat();
-
-			long size = fwrite(&param_value, sizeof(float), 1, stdio_t::FileHandles[param_handle]);
-			if ( size == -1 ) {    // error while writing
-				throw Runtime::Exceptions::RuntimeException("error while writing file");
-			}
-
-			*result = Runtime::Int32Type((int)size);
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		float param_value = (*it++).value().toFloat();
+
+		long size = fwrite(&param_value, sizeof(float), 1, stdio_t::FileHandles[param_handle]);
+		if ( size == -1 ) {    // error while writing
+			throw Runtime::Exceptions::RuntimeException("error while writing file");
 		}
+
+		*result = Runtime::Int32Type((int)size);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -190,35 +163,26 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			int param_value = (*it++).value().toInt();
-
-			long size = fwrite(&param_value, sizeof(int), 1, stdio_t::FileHandles[param_handle]);
-			if ( size == -1 ) {    // error while writing
-				throw Runtime::Exceptions::RuntimeException("error while writing file");
-			}
-
-			*result = Runtime::Int32Type((int)size);
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		int param_value = (*it++).value().toInt();
+
+		long size = fwrite(&param_value, sizeof(int), 1, stdio_t::FileHandles[param_handle]);
+		if ( size == -1 ) {    // error while writing
+			throw Runtime::Exceptions::RuntimeException("error while writing file");
 		}
+
+		*result = Runtime::Int32Type((int)size);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -238,36 +202,27 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException("invalid file handle");
-			}
-
-			std::string param_value = (*it++).value().toStdString();
-
-			//long size = fwrite(&param_value, sizeof(char), strlen(param_value.c_str()), stdio_t::FileHandles[param_handle]);
-			long size = fputs(param_value.c_str(), stdio_t::FileHandles[param_handle]);
-			if ( size == -1 ) {    // error while writing
-				throw Runtime::Exceptions::RuntimeException("error while writing file");
-			}
-
-			*result = Runtime::Int32Type(static_cast<int>(size));
+		if ( stdio_t::FileHandles.find(param_handle) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException("invalid file handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		std::string param_value = (*it++).value().toStdString();
+
+		//long size = fwrite(&param_value, sizeof(char), strlen(param_value.c_str()), stdio_t::FileHandles[param_handle]);
+		long size = fputs(param_value.c_str(), stdio_t::FileHandles[param_handle]);
+		if ( size == -1 ) {    // error while writing
+			throw Runtime::Exceptions::RuntimeException("error while writing file");
 		}
+
+		*result = Runtime::Int32Type(static_cast<int>(size));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/getchar.h
+++ b/Projects/Extensions/LIBC/stdio/getchar.h
@@ -45,20 +45,11 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-		    *result = Runtime::Int32Type( getchar() );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( getchar() );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/perror.h
+++ b/Projects/Extensions/LIBC/stdio/perror.h
@@ -45,24 +45,15 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object */*result*/, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object */*result*/ )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_s = (*it++).value().toStdString();
+		auto param_s = (*it++).value().toStdString();
 
-			perror( param_s.c_str() );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		perror( param_s.c_str() );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/putchar.h
+++ b/Projects/Extensions/LIBC/stdio/putchar.h
@@ -46,24 +46,15 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-            ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-            auto param_ch = (*it++).value().toInt();
+		auto param_ch = (*it++).value().toInt();
 
-            *result = Runtime::Int32Type( putchar( param_ch ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( putchar( param_ch ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/puts.h
+++ b/Projects/Extensions/LIBC/stdio/puts.h
@@ -46,24 +46,15 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-            ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-            auto param_str = (*it++).value().toStdString();
+		auto param_str = (*it++).value().toStdString();
 
-            *result = Runtime::Int32Type( puts( param_str.c_str() ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( puts( param_str.c_str() ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/remove.h
+++ b/Projects/Extensions/LIBC/stdio/remove.h
@@ -46,24 +46,15 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-            ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-            auto param_pathname = (*it++).value().toStdString();
+		auto param_pathname = (*it++).value().toStdString();
 
-            *result = Runtime::Int32Type( remove( param_pathname.c_str() ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( remove( param_pathname.c_str() ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/rename.h
+++ b/Projects/Extensions/LIBC/stdio/rename.h
@@ -47,25 +47,16 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-            ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-            auto param_old_filename = (*it++).value().toStdString();
-            auto param_new_filename = (*it++).value().toStdString();
+		auto param_old_filename = (*it++).value().toStdString();
+		auto param_new_filename = (*it++).value().toStdString();
 
-            *result = Runtime::Int32Type( rename( param_old_filename.c_str(), param_new_filename.c_str() ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( rename( param_old_filename.c_str(), param_new_filename.c_str() ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/rewind.h
+++ b/Projects/Extensions/LIBC/stdio/rewind.h
@@ -46,28 +46,19 @@ public:
 		setSignature( params );
 	}
 
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList &params, Runtime::Object */*result*/, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object */*result*/ )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_handle = (*it++).value().toInt();
+		auto param_handle = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find( param_handle ) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
-			}
-
-			rewind( stdio_t::FileHandles[param_handle] );
+		if ( stdio_t::FileHandles.find( param_handle ) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
 
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		rewind( stdio_t::FileHandles[param_handle] );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/tmpfile.h
+++ b/Projects/Extensions/LIBC/stdio/tmpfile.h
@@ -45,29 +45,20 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-            int result_handle = 0;
+		int result_handle = 0;
 
-			FILE* fileHandle = tmpfile();
-			if ( fileHandle ) {
-				result_handle = stdio_t::FileHandles.size();
+		FILE* fileHandle = tmpfile();
+		if ( fileHandle ) {
+			result_handle = stdio_t::FileHandles.size();
 
-				stdio_t::FileHandles.insert(std::make_pair(result_handle, fileHandle));
-			}
-
-            *result = Runtime::Int32Type( result_handle );
+			stdio_t::FileHandles.insert(std::make_pair(result_handle, fileHandle));
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( result_handle );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/tmpnam.h
+++ b/Projects/Extensions/LIBC/stdio/tmpnam.h
@@ -44,24 +44,15 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
 #ifdef __APPLE__
-			*result = Runtime::StringType( std::to_string( mkstemp( nullptr ) ) );  // tmpnam is deprecated
+		*result = Runtime::StringType( std::to_string( mkstemp( nullptr ) ) );  // tmpnam is deprecated
 #else
-			*result = Runtime::StringType( std::string( tmpnam( nullptr ) ) );
+		*result = Runtime::StringType( std::string( tmpnam( nullptr ) ) );
 #endif
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdio/ungetc.h
+++ b/Projects/Extensions/LIBC/stdio/ungetc.h
@@ -45,29 +45,20 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			auto param_ch     = (*it++).value().toInt();
-			auto param_stream = (*it++).value().toInt();
+		auto param_ch     = (*it++).value().toInt();
+		auto param_stream = (*it++).value().toInt();
 
-			if ( stdio_t::FileHandles.find( param_stream ) == stdio_t::FileHandles.end() ) {
-				throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
-			}
-
-			*result = Runtime::Int32Type( ungetc( param_ch, stdio_t::FileHandles[ param_stream ] ) );
+		if ( stdio_t::FileHandles.find( param_stream ) == stdio_t::FileHandles.end() ) {
+			throw Runtime::Exceptions::RuntimeException( "invalid file handle" );
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
 
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( ungetc( param_ch, stdio_t::FileHandles[ param_stream ] ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/LIBC/stdlib/abs.h
+++ b/Projects/Extensions/LIBC/stdlib/abs.h
@@ -43,24 +43,15 @@ public:
     }
 
 public:
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
     {
         ParameterList list = mergeParameters(params);
 
-        try {
-            ParameterList::const_iterator it = list.begin();
+        ParameterList::const_iterator it = list.begin();
 
-            auto param_arg = (*it++).value().toDouble();
+        auto param_arg = (*it++).value().toDouble();
 
-            *result = Runtime::DoubleType(std::abs(param_arg));
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        *result = Runtime::DoubleType(std::abs(param_arg));
 
         return Runtime::ControlFlow::Normal;
     }
@@ -80,24 +71,15 @@ public:
     }
 
 public:
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
     {
         ParameterList list = mergeParameters(params);
 
-        try {
-            ParameterList::const_iterator it = list.begin();
+        ParameterList::const_iterator it = list.begin();
 
-            auto param_arg = (*it++).value().toFloat();
+        auto param_arg = (*it++).value().toFloat();
 
-            *result = Runtime::FloatType(std::abs(param_arg));
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        *result = Runtime::FloatType(std::abs(param_arg));
 
         return Runtime::ControlFlow::Normal;
     }
@@ -117,24 +99,15 @@ public:
     }
 
 public:
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
     {
         ParameterList list = mergeParameters(params);
 
-        try {
-            ParameterList::const_iterator it = list.begin();
+        ParameterList::const_iterator it = list.begin();
 
-            auto param_arg = (*it++).value().toInt();
+        auto param_arg = (*it++).value().toInt();
 
-            result->assign(Runtime::Int32Type(std::abs(param_arg)));
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        result->assign(Runtime::Int32Type(std::abs(param_arg)));
 
         return Runtime::ControlFlow::Normal;
     }

--- a/Projects/Extensions/LIBC/stdlib/rand.h
+++ b/Projects/Extensions/LIBC/stdlib/rand.h
@@ -38,18 +38,9 @@ public:
     }
 
 public:
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& /*params*/, Runtime::Object* result, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& /*params*/, Runtime::Object* result )
     {
-        try {
-            *result = Runtime::Int32Type(rand());
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        *result = Runtime::Int32Type(rand());
 
         return Runtime::ControlFlow::Normal;
     }

--- a/Projects/Extensions/LIBC/stdlib/srand.h
+++ b/Projects/Extensions/LIBC/stdlib/srand.h
@@ -37,24 +37,15 @@ public:
     }
 
 public:
-    Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* /*result*/, const Token& token)
+    Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* /*result*/ )
     {
         ParameterList list = mergeParameters(params);
 
-        try {
-            ParameterList::const_iterator it = list.begin();
+        ParameterList::const_iterator it = list.begin();
 
-            auto param_seed = (it++)->value().toInt();
+        auto param_seed = (it++)->value().toInt();
 
-            srand(param_seed);
-        }
-        catch ( std::exception& e ) {
-            Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-            *data = Runtime::StringType(std::string(e.what()));
-
-            Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-            return Runtime::ControlFlow::Throw;
-        }
+        srand(param_seed);
 
         return Runtime::ControlFlow::Normal;
     }

--- a/Projects/Extensions/System/Ascii.h
+++ b/Projects/Extensions/System/Ascii.h
@@ -38,25 +38,16 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::ostringstream character;
-			character << (char)(*it++).value().toInt();
+		std::ostringstream character;
+		character << (char)(*it++).value().toInt();
 
-			*result = Runtime::StringType(character.str());
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType(character.str());
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Console/Cerr.h
+++ b/Projects/Extensions/System/Console/Cerr.h
@@ -29,33 +29,24 @@ class Cerr : public ExtensionMethod
 {
 public:
 	Cerr()
-	: ExtensionMethod(0, "cerr", Designtime::StringType::TYPENAME)
+	: ExtensionMethod( 0, "cerr", Designtime::StringType::TYPENAME )
 	{
 		ParameterList params;
-		params.push_back(Parameter::CreateDesigntime("text", Common::TypeDeclaration(Designtime::StringType::TYPENAME), VALUE_NONE, true));
+		params.push_back( Parameter::CreateDesigntime( "text", Common::TypeDeclaration( Designtime::StringType::TYPENAME ), VALUE_NONE, true ) );
 
-		setSignature(params);
+		setSignature( params );
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* /*result*/, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* /*result*/ )
 	{
-		ParameterList list = mergeParameters(params);
+		auto list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		auto it = list.begin();
 
-			std::cerr << (*it++).value().toStdString();
+		std::cerr << (*it++).value().toStdString();
 
-			mOutMode = CERR;
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		mOutMode = CERR;
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Console/Cin.h
+++ b/Projects/Extensions/System/Console/Cin.h
@@ -29,31 +29,22 @@ class Cin : public ExtensionMethod
 {
 public:
 	Cin()
-	: ExtensionMethod(0, "cin", Designtime::StringType::TYPENAME)
+	: ExtensionMethod( 0, "cin", Designtime::StringType::TYPENAME )
 	{
 		ParameterList params;
 
-		setSignature(params);
+		setSignature( params );
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& /*params*/, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& /*params*/, Runtime::Object* result )
 	{
-		try {
-			std::string text;
+		std::string text;
 
-			getline(std::cin >> std::ws, text);
-			std::cin.clear();
+		getline( std::cin >> std::ws, text );
+		std::cin.clear();
 
-			*result = Runtime::StringType(text);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType( text );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Console/Cout.h
+++ b/Projects/Extensions/System/Console/Cout.h
@@ -28,33 +28,24 @@ class Cout : public ExtensionMethod
 {
 public:
 	Cout()
-	: ExtensionMethod(0, "cout", Designtime::StringType::TYPENAME)
+	: ExtensionMethod( 0, "cout", Designtime::StringType::TYPENAME )
 	{
 		ParameterList params;
-		params.push_back(Parameter::CreateDesigntime("text", Common::TypeDeclaration(Designtime::StringType::TYPENAME), VALUE_NONE, true));
+		params.push_back( Parameter::CreateDesigntime( "text", Common::TypeDeclaration( Designtime::StringType::TYPENAME ), VALUE_NONE, true ) );
 
-		setSignature(params);
+		setSignature( params );
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* /*result*/, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* /*result*/ )
 	{
-		ParameterList list = mergeParameters(params);
+		auto list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		auto it = list.begin();
 
-			std::cout << (*it++).value().toStdString();
+		std::cout << (*it++).value().toStdString();
 
-			mOutMode = COUT;
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		mOutMode = COUT;
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Console/Endl.h
+++ b/Projects/Extensions/System/Console/Endl.h
@@ -28,30 +28,21 @@ class Endl : public ExtensionMethod
 {
 public:
 	Endl()
-	: ExtensionMethod(0, "endl", Designtime::StringType::TYPENAME)
+	: ExtensionMethod( 0, "endl", Designtime::StringType::TYPENAME )
 	{
 		ParameterList params;
 
-		setSignature(params);
+		setSignature( params );
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& /*params*/, Runtime::Object* /*result*/, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& /*params*/, Runtime::Object* /*result*/ )
 	{
-		try {
-			if ( mOutMode == CERR ) {
-				std::cerr << std::endl;
-			}
-			else if ( mOutMode == COUT ) {
-				std::cout << std::endl;
-			}
+		if ( mOutMode == CERR ) {
+			std::cerr << std::endl;
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		else if ( mOutMode == COUT ) {
+			std::cout << std::endl;
 		}
 
 		return Runtime::ControlFlow::Normal;

--- a/Projects/Extensions/System/Fork.h
+++ b/Projects/Extensions/System/Fork.h
@@ -37,18 +37,9 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& /*params*/, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& /*params*/, Runtime::Object* result )
 	{
-		try {
-			*result = Runtime::Int32Type(fork());
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(fork());
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/GetEnv.h
+++ b/Projects/Extensions/System/GetEnv.h
@@ -36,31 +36,22 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_name = (*it++).value().toStdString();
+		std::string param_name = (*it++).value().toStdString();
 
-			std::string result_value;
+		std::string result_value;
 
-			char* val = getenv(param_name.c_str());
-			if ( val ) {
-				result_value = std::string(val);
-			}
-
-			*result = Runtime::StringType(result_value);
+		char* val = getenv(param_name.c_str());
+		if ( val ) {
+			result_value = std::string(val);
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType(result_value);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Network/Accept.h
+++ b/Projects/Extensions/System/Network/Accept.h
@@ -38,26 +38,17 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
-		ParameterList list = mergeParameters(params);
+		auto list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		auto it = list.begin();
 
-			int param_sockfd = (*it++).value().toInt();
+		auto param_sockfd = (*it++).value().toInt();
 
-			int handle = accept(param_sockfd, nullptr, nullptr);
+		auto return_handle = accept(param_sockfd, nullptr, nullptr);
 
-			*result = Runtime::Int32Type(handle);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(return_handle);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Network/Bind.h
+++ b/Projects/Extensions/System/Network/Bind.h
@@ -42,27 +42,18 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_sockfd = (*it++).value().toInt();
-			Runtime::Object* param_addr = Controller::Instance().memory()->get((*it++).reference());
+		int param_sockfd = (*it++).value().toInt();
+		Runtime::Object* param_addr = Controller::Instance().memory()->get((*it++).reference());
 
-			int handle = evaluate(param_sockfd, param_addr);
+		int handle = evaluate(param_sockfd, param_addr);
 
-			*result = Runtime::Int32Type(handle);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(handle);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Network/Close.h
+++ b/Projects/Extensions/System/Network/Close.h
@@ -40,26 +40,17 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_sockfd = (*it++).value().toInt();
+		int param_sockfd = (*it++).value().toInt();
 
-			int handle = close(param_sockfd);
+		int handle = close(param_sockfd);
 
-			*result = Runtime::Int32Type(handle);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(handle);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Network/Connect.h
+++ b/Projects/Extensions/System/Network/Connect.h
@@ -39,27 +39,18 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_sockfd = (*it++).value().toInt();
-			Runtime::Object* param_addr = Controller::Instance().memory()->get((*it++).reference());
+		int param_sockfd = (*it++).value().toInt();
+		Runtime::Object* param_addr = Controller::Instance().memory()->get((*it++).reference());
 
-			int handle = evaluate(param_sockfd, param_addr);
+		int handle = evaluate(param_sockfd, param_addr);
 
-			*result = Runtime::Int32Type(handle);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(handle);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Network/Listen.h
+++ b/Projects/Extensions/System/Network/Listen.h
@@ -38,27 +38,18 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_sockfd = (*it++).value().toInt();
-			int param_backlog_queue_size = (*it++).value().toInt();
+		int param_sockfd = (*it++).value().toInt();
+		int param_backlog_queue_size = (*it++).value().toInt();
 
-			int handle = listen(param_sockfd, param_backlog_queue_size);
+		int handle = listen(param_sockfd, param_backlog_queue_size);
 
-			*result = Runtime::Int32Type(handle);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(handle);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Network/Read.h
+++ b/Projects/Extensions/System/Network/Read.h
@@ -31,31 +31,22 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
 
-			bool value = false;
+		bool value = false;
 
-			long size = read(param_handle, &value, sizeof(bool));
-			if ( size == -1 ) {    // error while reading
-				throw Runtime::Exceptions::RuntimeException("error while reading handle");
-			}
-
-			*result = Runtime::BoolType(value);
+		long size = read(param_handle, &value, sizeof(bool));
+		if ( size == -1 ) {    // error while reading
+			throw Runtime::Exceptions::RuntimeException("error while reading handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::BoolType(value);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -74,31 +65,22 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
 
-			double value = 0.0;
+		double value = 0.0;
 
-			long size = read(param_handle, &value, sizeof(double));
-			if ( size == -1 ) {    // error while reading
-				throw Runtime::Exceptions::RuntimeException("error while reading handle");
-			}
-
-			*result = Runtime::DoubleType(value);
+		long size = read(param_handle, &value, sizeof(double));
+		if ( size == -1 ) {    // error while reading
+			throw Runtime::Exceptions::RuntimeException("error while reading handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::DoubleType(value);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -117,31 +99,22 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
 
-			float value = 0.f;
+		float value = 0.f;
 
-			long size = read(param_handle, &value, sizeof(float));
-			if ( size == -1 ) {    // error while reading
-				throw Runtime::Exceptions::RuntimeException("error while reading handle");
-			}
-
-			*result = Runtime::FloatType(value);
+		long size = read(param_handle, &value, sizeof(float));
+		if ( size == -1 ) {    // error while reading
+			throw Runtime::Exceptions::RuntimeException("error while reading handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::FloatType(value);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -160,31 +133,22 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
 
-			int value = 0;
+		int value = 0;
 
-			long size = read(param_handle, &value, sizeof(int));
-			if ( size == -1 ) {    // error while reading
-				throw Runtime::Exceptions::RuntimeException("error while reading handle");
-			}
-
-			*result = Runtime::Int32Type(value);
+		long size = read(param_handle, &value, sizeof(int));
+		if ( size == -1 ) {    // error while reading
+			throw Runtime::Exceptions::RuntimeException("error while reading handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(value);
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -204,45 +168,36 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
-			int param_length = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
+		int param_length = (*it++).value().toInt();
 
-			std::string value;
+		std::string value;
 
-			while ( param_length > 0 || param_length == -1 ) {
-				char charValue;
+		while ( param_length > 0 || param_length == -1 ) {
+			char charValue;
 
-				long size = read(param_handle, &charValue, sizeof(char));
-				if ( size == -1 ) {    // error while reading
-					return Runtime::ControlFlow::Throw;
-				}
-				if ( size == 0 ) {	// EOF reached
-					break;
-				}
-
-				value += charValue;
-
-				if ( param_length > 0 ) {
-					param_length--;
-				}
+			long size = read(param_handle, &charValue, sizeof(char));
+			if ( size == -1 ) {    // error while reading
+				return Runtime::ControlFlow::Throw;
+			}
+			if ( size == 0 ) {	// EOF reached
+				break;
 			}
 
-			*result = Runtime::StringType(value);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
+			value += charValue;
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+			if ( param_length > 0 ) {
+				param_length--;
+			}
 		}
+
+		*result = Runtime::StringType(value);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Network/Shutdown.h
+++ b/Projects/Extensions/System/Network/Shutdown.h
@@ -41,27 +41,18 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_1 = (*it++).value().toInt();
-			int param_2 = (*it++).value().toInt();
+		int param_1 = (*it++).value().toInt();
+		int param_2 = (*it++).value().toInt();
 
-			int handle = shutdown(param_1, param_2);
+		int handle = shutdown(param_1, param_2);
 
-			*result = Runtime::Int32Type(handle);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(handle);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Network/Socket.h
+++ b/Projects/Extensions/System/Network/Socket.h
@@ -39,28 +39,19 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_domain = (*it++).value().toInt();
-			int param_type = (*it++).value().toInt();
-			int param_protocol = (*it++).value().toInt();
+		int param_domain = (*it++).value().toInt();
+		int param_type = (*it++).value().toInt();
+		int param_protocol = (*it++).value().toInt();
 
-			int handle = socket(param_domain, param_type, param_protocol);
+		int handle = socket(param_domain, param_type, param_protocol);
 
-			*result = Runtime::Int32Type(handle);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(handle);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Network/Write.h
+++ b/Projects/Extensions/System/Network/Write.h
@@ -32,31 +32,22 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
 
-			bool value = (*it++).value().toBool();
+		bool value = (*it++).value().toBool();
 
-			long size = write(param_handle, &value, sizeof(bool));
-			if ( size == -1 ) {    // error while writing
-				throw Runtime::Exceptions::RuntimeException("error while writing handle");
-			}
-
-			*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
+		long size = write(param_handle, &value, sizeof(bool));
+		if ( size == -1 ) {    // error while writing
+			throw Runtime::Exceptions::RuntimeException("error while writing handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -76,31 +67,22 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
 
-			double value = (*it++).value().toDouble();
+		double value = (*it++).value().toDouble();
 
-			long size = write(param_handle, &value, sizeof(double));
-			if ( size == -1 ) {    // error while writing
-				throw Runtime::Exceptions::RuntimeException("error while writing handle");
-			}
-
-			*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
+		long size = write(param_handle, &value, sizeof(double));
+		if ( size == -1 ) {    // error while writing
+			throw Runtime::Exceptions::RuntimeException("error while writing handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -120,31 +102,22 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
 
-			float value = (*it++).value().toFloat();
+		float value = (*it++).value().toFloat();
 
-			long size = write(param_handle, &value, sizeof(float));
-			if ( size == -1 ) {    // error while writing
-				throw Runtime::Exceptions::RuntimeException("error while writing handle");
-			}
-
-			*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
+		long size = write(param_handle, &value, sizeof(float));
+		if ( size == -1 ) {    // error while writing
+			throw Runtime::Exceptions::RuntimeException("error while writing handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -164,31 +137,22 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
 
-			int value = (*it++).value().toInt();
+		int value = (*it++).value().toInt();
 
-			long size = write(param_handle, &value, sizeof(int));
-			if ( size == -1 ) {    // error while writing
-				throw Runtime::Exceptions::RuntimeException("error while writing handle");
-			}
-
-			*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
+		long size = write(param_handle, &value, sizeof(int));
+		if ( size == -1 ) {    // error while writing
+			throw Runtime::Exceptions::RuntimeException("error while writing handle");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
 
 		return Runtime::ControlFlow::Normal;
 	}
@@ -208,37 +172,28 @@ public:
 		setSignature(params);
 	}
 
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList &params, Runtime::Object *result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList &params, Runtime::Object *result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			int param_handle = (*it++).value().toInt();
+		int param_handle = (*it++).value().toInt();
 
-			std::string value = params.back().value().toStdString();
-			unsigned long count = 0;
-			long size = 0;
+		std::string value = params.back().value().toStdString();
+		unsigned long count = 0;
+		long size = 0;
 
-			while ( count < value.size() ) {
-				size = write(param_handle, &value[count], sizeof(char));
-				if ( size == -1 ) {    // error while writing
-					throw Runtime::Exceptions::RuntimeException("error while writing handle");
-				}
-
-				count++;
+		while ( count < value.size() ) {
+			size = write(param_handle, &value[count], sizeof(char));
+			if ( size == -1 ) {    // error while writing
+				throw Runtime::Exceptions::RuntimeException("error while writing handle");
 			}
 
-			*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
+			count++;
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( static_cast<int32_t>( size ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/PutEnv.h
+++ b/Projects/Extensions/System/PutEnv.h
@@ -36,24 +36,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_name = (*it++).value().toStdString();
+		std::string param_name = (*it++).value().toStdString();
 
-			*result = Runtime::Int32Type(putenv(const_cast<char*>(param_name.c_str())));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(putenv(const_cast<char*>(param_name.c_str())));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Reflection/CreateInstance.h
+++ b/Projects/Extensions/System/Reflection/CreateInstance.h
@@ -40,26 +40,17 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_type = (*it++).value().toStdString();
+		std::string param_type = (*it++).value().toStdString();
 
-			Runtime::Object* newInstance = Controller::Instance().repository()->createReference(param_type, ANONYMOUS_OBJECT, PrototypeConstraints(), Repository::InitilizationType::Final);
+		Runtime::Object* newInstance = Controller::Instance().repository()->createReference(param_type, ANONYMOUS_OBJECT, PrototypeConstraints(), Repository::InitilizationType::Final);
 
-			*result = *newInstance;
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = *newInstance;
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Reflection/IsKnownType.h
+++ b/Projects/Extensions/System/Reflection/IsKnownType.h
@@ -40,24 +40,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_type = (*it++).value().toStdString();
+		std::string param_type = (*it++).value().toStdString();
 
-			*result = Runtime::BoolType( Controller::Instance().repository()->findBluePrintObject(param_type) != nullptr );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::BoolType( Controller::Instance().repository()->findBluePrintObject(param_type) != nullptr );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/SetEnv.h
+++ b/Projects/Extensions/System/SetEnv.h
@@ -45,31 +45,22 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_name = (*it++).value().toStdString();
-			std::string param_value = (*it++).value().toStdString();
+		std::string param_name = (*it++).value().toStdString();
+		std::string param_value = (*it++).value().toStdString();
 
 #ifdef _WIN32
-			*result = Runtime::Int32Type(SetEnvironmentVariable(param_name.c_str(), param_value.c_str()));
+		*result = Runtime::Int32Type(SetEnvironmentVariable(param_name.c_str(), param_value.c_str()));
 #else
-			auto param_overwrite = (*it++).value().toInt();
+		auto param_overwrite = (*it++).value().toInt();
 
-			*result = Runtime::Int32Type(setenv(param_name.c_str(), param_value.c_str(), param_overwrite));
+		*result = Runtime::Int32Type(setenv(param_name.c_str(), param_value.c_str(), param_overwrite));
 #endif
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/SetKeyboardBlockingMode.h
+++ b/Projects/Extensions/System/SetKeyboardBlockingMode.h
@@ -39,24 +39,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* /*result*/, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* /*result*/ )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			bool param_mode = (*it++).value().toBool();
+		bool param_mode = (*it++).value().toBool();
 
-			setKeyboardBlockingMode(param_mode);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		setKeyboardBlockingMode(param_mode);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Sleep.h
+++ b/Projects/Extensions/System/Sleep.h
@@ -41,28 +41,19 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* /*result*/, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* /*result*/ )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			long param_millis = (*it++).value().toInt();
+		long param_millis = (*it++).value().toInt();
 
 #ifdef _WIN32
-			_sleep(param_millis);
+		_sleep(param_millis);
 #else
-			std::this_thread::sleep_for(std::chrono::milliseconds(param_millis));
+		std::this_thread::sleep_for(std::chrono::milliseconds(param_millis));
 #endif
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/StrFTime.h
+++ b/Projects/Extensions/System/Strings/StrFTime.h
@@ -41,38 +41,29 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_format = (*it++).value().toStdString();
-			int32_t param_time = (*it++).value().toInt();
+		std::string param_format = (*it++).value().toStdString();
+		int32_t param_time = (*it++).value().toInt();
 
-			std::time_t time;
-			if ( param_time ) {
-				time = param_time;
-			}
-			else {
-				time = std::time( nullptr );
-			}
-
-			std::tm tm = *std::localtime( &time );
-
-			std::stringstream ssr;
-			ssr << std::put_time( &tm, param_format.c_str() );
-
-			*result = Runtime::StringType( ssr.str() );
+		std::time_t time;
+		if ( param_time ) {
+			time = param_time;
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
+		else {
+			time = std::time( nullptr );
 		}
+
+		std::tm tm = *std::localtime( &time );
+
+		std::stringstream ssr;
+		ssr << std::put_time( &tm, param_format.c_str() );
+
+		*result = Runtime::StringType( ssr.str() );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/StrFind.h
+++ b/Projects/Extensions/System/Strings/StrFind.h
@@ -42,28 +42,19 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_source = (*it++).value().toStdString();
-			std::string param_target = (*it++).value().toStdString();
-			unsigned long param_position = (*it).value().toInt();
+		std::string param_source = (*it++).value().toStdString();
+		std::string param_target = (*it++).value().toStdString();
+		unsigned long param_position = (*it).value().toInt();
 
-			int my_result = (int)param_source.find(param_target, param_position);
+		int my_result = (int)param_source.find(param_target, param_position);
 
-			*result = Runtime::Int32Type(my_result);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type(my_result);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/StrLPad.h
+++ b/Projects/Extensions/System/Strings/StrLPad.h
@@ -41,37 +41,28 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_value = (*it++).value().toStdString();
-			int param_length = (*it++).value().toInt();
-			std::string param_pattern = (*it++).value().toStdString();
+		std::string param_value = (*it++).value().toStdString();
+		int param_length = (*it++).value().toInt();
+		std::string param_pattern = (*it++).value().toStdString();
 
-			if ( param_length < 0 ) {
-				throw Runtime::Exceptions::SizeException("invalid length");
-			}
-			if ( param_pattern.size() != 1 ) {
-				throw Runtime::Exceptions::SizeException("invalid pattern size");
-			}
-
-            if ( (size_t)param_length > param_value.size() ) {
-                param_value.insert(param_value.begin(), param_length - param_value.size(), param_pattern[0]);
-            }
-
-			*result = Runtime::StringType(param_value);
+		if ( param_length < 0 ) {
+			throw Runtime::Exceptions::SizeException("invalid length");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		if ( param_pattern.size() != 1 ) {
+			throw Runtime::Exceptions::SizeException("invalid pattern size");
 		}
+
+		if ( (size_t)param_length > param_value.size() ) {
+			param_value.insert(param_value.begin(), param_length - param_value.size(), param_pattern[0]);
+		}
+
+		*result = Runtime::StringType(param_value);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/StrLTrim.h
+++ b/Projects/Extensions/System/Strings/StrLTrim.h
@@ -37,24 +37,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_value = (*it++).value().toStdString();
+		std::string param_value = (*it++).value().toStdString();
 
-			*result = Runtime::StringType(::Utils::Tools::stringTrimLeft(param_value));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType(::Utils::Tools::stringTrimLeft(param_value));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/StrPTime.h
+++ b/Projects/Extensions/System/Strings/StrPTime.h
@@ -41,33 +41,24 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters( params );
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_format = (*it++).value().toStdString();
-            std::string param_time = (*it++).value().toStdString();
+		std::string param_format = (*it++).value().toStdString();
+		std::string param_time = (*it++).value().toStdString();
 
-            struct tm tm{};
+		struct tm tm{};
 
-            if ( strptime(param_time.c_str(), param_format.c_str(), &tm ) ) {
-                auto time = mktime( &tm );
+		if ( strptime(param_time.c_str(), param_format.c_str(), &tm ) ) {
+			auto time = mktime( &tm );
 
-                *result = Runtime::Int32Type( time );
-            }
-            else {
-                *result = Runtime::Int32Type( 0 );
-            }
+			*result = Runtime::Int32Type( time );
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
+		else {
+			*result = Runtime::Int32Type( 0 );
 		}
 
 		return Runtime::ControlFlow::Normal;

--- a/Projects/Extensions/System/Strings/StrPos.h
+++ b/Projects/Extensions/System/Strings/StrPos.h
@@ -39,31 +39,22 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_value = (*it++).value().toStdString();
-			unsigned long param_index = (*it++).value().toInt();
+		std::string param_value = (*it++).value().toStdString();
+		unsigned long param_index = (*it++).value().toInt();
 
-			if ( param_index > param_value.size() ) {
-				throw Runtime::Exceptions::SizeException("index " + Utils::Tools::toString(param_index) + " out of bounds (" + Utils::Tools::toString(param_value.size()) + ")");
-			}
-
-			std::string result_value = param_value.substr(param_index, 1);
-
-			*result = Runtime::StringType(result_value);
+		if ( param_index > param_value.size() ) {
+			throw Runtime::Exceptions::SizeException("index " + Utils::Tools::toString(param_index) + " out of bounds (" + Utils::Tools::toString(param_value.size()) + ")");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		std::string result_value = param_value.substr(param_index, 1);
+
+		*result = Runtime::StringType(result_value);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/StrRPad.h
+++ b/Projects/Extensions/System/Strings/StrRPad.h
@@ -40,37 +40,28 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_value = (*it++).value().toStdString();
-			int param_length = (*it++).value().toInt();
-			std::string param_pattern = (*it++).value().toStdString();
+		std::string param_value = (*it++).value().toStdString();
+		int param_length = (*it++).value().toInt();
+		std::string param_pattern = (*it++).value().toStdString();
 
-			if ( param_length < 0 ) {
-				throw Runtime::Exceptions::SizeException("invalid length");
-			}
-			if ( param_pattern.size() != 1 ) {
-				throw Runtime::Exceptions::SizeException("invalid pattern size");
-			}
-
-			if ( (size_t)param_length > param_value.size() ) {
-			    param_value.append(param_length - param_value.size(), param_pattern[0]);
-            }
-
-			*result = Runtime::StringType(param_value);
+		if ( param_length < 0 ) {
+			throw Runtime::Exceptions::SizeException("invalid length");
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
+		if ( param_pattern.size() != 1 ) {
+			throw Runtime::Exceptions::SizeException("invalid pattern size");
 		}
+
+		if ( (size_t)param_length > param_value.size() ) {
+			param_value.append(param_length - param_value.size(), param_pattern[0]);
+		}
+
+		*result = Runtime::StringType(param_value);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/StrRTrim.h
+++ b/Projects/Extensions/System/Strings/StrRTrim.h
@@ -37,24 +37,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_value = (*it++).value().toStdString();
+		std::string param_value = (*it++).value().toStdString();
 
-			*result = Runtime::StringType(::Utils::Tools::stringTrimRight(param_value));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType(::Utils::Tools::stringTrimRight(param_value));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/StrTrim.h
+++ b/Projects/Extensions/System/Strings/StrTrim.h
@@ -37,24 +37,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_value = (*it++).value().toStdString();
+		std::string param_value = (*it++).value().toStdString();
 
-			*result = Runtime::StringType(::Utils::Tools::stringTrim(param_value));
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType(::Utils::Tools::stringTrim(param_value));
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/SubStr.h
+++ b/Projects/Extensions/System/Strings/SubStr.h
@@ -40,32 +40,23 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_value = (*it++).value().toStdString();
-			unsigned long param_start = (*it++).value().toInt();
-			unsigned long param_end = std::string::npos;
+		std::string param_value = (*it++).value().toStdString();
+		unsigned long param_start = (*it++).value().toInt();
+		unsigned long param_end = std::string::npos;
 
-			if ( params.size() >= 3 ) {
-				param_end = (*it++).value().toInt();
-			}
-
-			std::string result_value = param_value.substr(param_start, param_end);
-
-			*result = Runtime::StringType(result_value);
+		if ( params.size() >= 3 ) {
+			param_end = (*it++).value().toInt();
 		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
 
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		std::string result_value = param_value.substr(param_start, param_end);
+
+		*result = Runtime::StringType(result_value);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/ToLower.h
+++ b/Projects/Extensions/System/Strings/ToLower.h
@@ -38,26 +38,17 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_value = (*it++).value().toStdString();
+		std::string param_value = (*it++).value().toStdString();
 
-			std::transform(param_value.begin(), param_value.end(), param_value.begin(), ::tolower);
+		std::transform(param_value.begin(), param_value.end(), param_value.begin(), ::tolower);
 
-			*result = Runtime::StringType(param_value);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType(param_value);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Strings/ToUpper.h
+++ b/Projects/Extensions/System/Strings/ToUpper.h
@@ -38,26 +38,17 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_value = (*it++).value().toStdString();
+		std::string param_value = (*it++).value().toStdString();
 
-			std::transform(param_value.begin(), param_value.end(), param_value.begin(), ::toupper);
+		std::transform(param_value.begin(), param_value.end(), param_value.begin(), ::toupper);
 
-			*result = Runtime::StringType(param_value);
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::StringType(param_value);
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Time/StdTime.h
+++ b/Projects/Extensions/System/Time/StdTime.h
@@ -38,18 +38,9 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& /*params*/, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& /*params*/, Runtime::Object* result )
 	{
-		try {
-			*result = Runtime::Int32Type( static_cast<int>( time( nullptr ) ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( static_cast<int>( time( nullptr ) ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Wait.h
+++ b/Projects/Extensions/System/Wait.h
@@ -38,18 +38,9 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& /*params*/, Runtime::Object* result, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& /*params*/, Runtime::Object* result )
 	{
-		try {
-			*result = Runtime::Int32Type( wait( NULL ) );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( wait( NULL ) );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/WaitPID.h
+++ b/Projects/Extensions/System/WaitPID.h
@@ -40,28 +40,19 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute( Common::ThreadId threadId, const ParameterList& params, Runtime::Object* result, const Token& token )
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* result )
 	{
         ParameterList list = mergeParameters( params );
 
-        try {
-            ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-            auto param_pid = (*it++).value().toInt();
-            auto param_options = (*it++).value().toInt();
+		auto param_pid = (*it++).value().toInt();
+		auto param_options = (*it++).value().toInt();
 
-            int status;
-            /*param_pid =*/ waitpid( param_pid, &status, param_options );
+		int status;
+		/*param_pid =*/ waitpid( param_pid, &status, param_options );
 
-            *result = Runtime::Int32Type( status );
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance( Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT );
-			*data = Runtime::StringType( std::string( e.what() ) );
-
-			Controller::Instance().thread( threadId )->exception() = Runtime::ExceptionData( data, token.position() );
-			return Runtime::ControlFlow::Throw;
-		}
+		*result = Runtime::Int32Type( status );
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/Write.h
+++ b/Projects/Extensions/System/Write.h
@@ -35,24 +35,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* /*result*/, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* /*result*/ )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_text = (*it++).value().toStdString();
+		std::string param_text = (*it++).value().toStdString();
 
-			std::cout << param_text;
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		std::cout << param_text;
 
 		return Runtime::ControlFlow::Normal;
 	}

--- a/Projects/Extensions/System/WriteLn.h
+++ b/Projects/Extensions/System/WriteLn.h
@@ -35,24 +35,15 @@ public:
 	}
 
 public:
-	Runtime::ControlFlow::E execute(Common::ThreadId threadId, const ParameterList& params, Runtime::Object* /*result*/, const Token& token)
+	Runtime::ControlFlow::E execute( const ParameterList& params, Runtime::Object* /*result*/ )
 	{
 		ParameterList list = mergeParameters(params);
 
-		try {
-			ParameterList::const_iterator it = list.begin();
+		ParameterList::const_iterator it = list.begin();
 
-			std::string param_text = (*it++).value().toStdString();
+		std::string param_text = (*it++).value().toStdString();
 
-			std::cout << param_text << std::endl;
-		}
-		catch ( std::exception& e ) {
-			Runtime::Object *data = Controller::Instance().repository()->createInstance(Runtime::StringType::TYPENAME, ANONYMOUS_OBJECT);
-			*data = Runtime::StringType(std::string(e.what()));
-
-			Controller::Instance().thread(threadId)->exception() = Runtime::ExceptionData(data, token.position());
-			return Runtime::ControlFlow::Throw;
-		}
+		std::cout << param_text << std::endl;
 
 		return Runtime::ControlFlow::Normal;
 	}


### PR DESCRIPTION
- exceptions are caught directly in (Tree)Interpreter.cpp instead of offloading it to the extension method itself
- removed threadId from extension method execute